### PR TITLE
Fix clear button click handler to clear tags

### DIFF
--- a/src/Components/Posts/Posts.jsx
+++ b/src/Components/Posts/Posts.jsx
@@ -449,8 +449,9 @@ console.log('filteredposts: ', filteredPosts)
                 />
 
                 {selectedTags.length > 0 && (
+                  //added onclick handler in x-box to make it work
                       <div className="clear-container">
-                        <div className="x-box">X</div>
+                        <div onClick={clearAllTags} className="x-box">X</div>
                           <a onClick={clearAllTags} className="clear-link">
                             Clear All
                           </a>


### PR DESCRIPTION
 #156 
 
Added an onClick handler to the "X" button next to the "Clear All" link. This enables users to clear all selected tags by clicking either the "X" or the "Clear All" text.

https://github.com/user-attachments/assets/4a5b56fa-e534-49f7-b9ad-6f7a1fb39645

